### PR TITLE
fix: ignore encrypted configs that cannot be decrypted

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -69,6 +69,31 @@ describe('normalize config', () => {
       process.env.CANARIST_ENCRYPTION_KEY = undefined;
     });
 
+    it('should ignore repositories that cannot be decrypted', () => {
+      // $ canarist -r a-repo -r enc:G6VSEW8lxBM3OYn7E3k4yGH61ExqKxx/rsUtKS/h8GU=
+      const config = normalizeConfig(
+        {
+          _: [],
+          help: false,
+          clean: true,
+          repository: [
+            'a-repo',
+            'enc:G6VSEW8lxBM3OYn7E3k4yGH61ExqKxx/rsUtKS/h8GU=',
+          ],
+        },
+        null
+      );
+
+      expect(config.repositories).toEqual<Config['repositories']>([
+        {
+          url: 'a-repo',
+          branch: 'master',
+          directory: 'a-repo',
+          commands: ['yarn test'],
+        },
+      ]);
+    });
+
     it('should normalize arguments for multiple repositories', () => {
       // $ canarist -r a-repo -r b-repo
       const config = normalizeConfig(

--- a/src/config.ts
+++ b/src/config.ts
@@ -209,15 +209,69 @@ export function normalizeConfig(
     '';
 
   if (typeof argv.repository === 'string') {
-    repositories.push(normalizeRepository(argv.repository));
+    try {
+      repositories.push(normalizeRepository(argv.repository));
+    } catch (error) {
+      console.warn(
+        `[canarist] could not parse repository config from: "${argv.repository}"`,
+        error
+      );
+    }
   } else if (Array.isArray(argv.repository)) {
-    repositories.push(...argv.repository.map(normalizeRepository));
+    repositories.push(
+      ...argv.repository
+        .map((repo) => {
+          try {
+            return normalizeRepository(repo);
+          } catch (error) {
+            console.warn(
+              `[canarist] could not parse repository config from:`,
+              repo,
+              error
+            );
+            return undefined;
+          }
+        })
+        .filter((repo): repo is RepositoryConfig => typeof repo !== 'undefined')
+    );
   } else if (argv.project && config && isProjectsConfig(config.config)) {
     if (project) {
-      repositories.push(...project.repositories.map(normalizeRepository));
+      repositories.push(
+        ...project.repositories
+          .map((repo) => {
+            try {
+              return normalizeRepository(repo);
+            } catch (error) {
+              console.warn(
+                `[canarist] could not parse repository config from:`,
+                repo,
+                error
+              );
+              return undefined;
+            }
+          })
+          .filter(
+            (repo): repo is RepositoryConfig => typeof repo !== 'undefined'
+          )
+      );
     }
   } else if (config && isSingleConfig(config.config)) {
-    repositories.push(...config.config.repositories.map(normalizeRepository));
+    repositories.push(
+      ...config.config.repositories
+        .map((repo) => {
+          try {
+            return normalizeRepository(repo);
+          } catch (error) {
+            console.warn(
+              `[canarist] could not parse repository config from:`,
+              repo,
+              error
+            );
+            return undefined;
+          }
+        })
+        .filter((repo): repo is RepositoryConfig => typeof repo !== 'undefined')
+    );
   }
 
   return {


### PR DESCRIPTION
In case we have no encryption key available or some other error occurs
during decryption of the repository config, we need to ignore that repo
and continue with the other repositories that can be decrypted / are not
decrypted.