### PR TITLE
Revert "fix: ignore encrypted configs that cannot be decrypted"

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -69,31 +69,6 @@ describe('normalize config', () => {
       process.env.CANARIST_ENCRYPTION_KEY = undefined;
     });
 
-    it('should ignore repositories that cannot be decrypted', () => {
-      // $ canarist -r a-repo -r enc:G6VSEW8lxBM3OYn7E3k4yGH61ExqKxx/rsUtKS/h8GU=
-      const config = normalizeConfig(
-        {
-          _: [],
-          help: false,
-          clean: true,
-          repository: [
-            'a-repo',
-            'enc:G6VSEW8lxBM3OYn7E3k4yGH61ExqKxx/rsUtKS/h8GU=',
-          ],
-        },
-        null
-      );
-
-      expect(config.repositories).toEqual<Config['repositories']>([
-        {
-          url: 'a-repo',
-          branch: 'master',
-          directory: 'a-repo',
-          commands: ['yarn test'],
-        },
-      ]);
-    });
-
     it('should normalize arguments for multiple repositories', () => {
       // $ canarist -r a-repo -r b-repo
       const config = normalizeConfig(

--- a/src/config.ts
+++ b/src/config.ts
@@ -209,69 +209,15 @@ export function normalizeConfig(
     '';
 
   if (typeof argv.repository === 'string') {
-    try {
-      repositories.push(normalizeRepository(argv.repository));
-    } catch (error) {
-      console.warn(
-        `[canarist] could not parse repository config from: "${argv.repository}"`,
-        error
-      );
-    }
+    repositories.push(normalizeRepository(argv.repository));
   } else if (Array.isArray(argv.repository)) {
-    repositories.push(
-      ...argv.repository
-        .map((repo) => {
-          try {
-            return normalizeRepository(repo);
-          } catch (error) {
-            console.warn(
-              `[canarist] could not parse repository config from:`,
-              repo,
-              error
-            );
-            return undefined;
-          }
-        })
-        .filter((repo): repo is RepositoryConfig => typeof repo !== 'undefined')
-    );
+    repositories.push(...argv.repository.map(normalizeRepository));
   } else if (argv.project && config && isProjectsConfig(config.config)) {
     if (project) {
-      repositories.push(
-        ...project.repositories
-          .map((repo) => {
-            try {
-              return normalizeRepository(repo);
-            } catch (error) {
-              console.warn(
-                `[canarist] could not parse repository config from:`,
-                repo,
-                error
-              );
-              return undefined;
-            }
-          })
-          .filter(
-            (repo): repo is RepositoryConfig => typeof repo !== 'undefined'
-          )
-      );
+      repositories.push(...project.repositories.map(normalizeRepository));
     }
   } else if (config && isSingleConfig(config.config)) {
-    repositories.push(
-      ...config.config.repositories
-        .map((repo) => {
-          try {
-            return normalizeRepository(repo);
-          } catch (error) {
-            console.warn(
-              `[canarist] could not parse repository config from:`,
-              repo,
-              error
-            );
-            return undefined;
-          }
-        })
-        .filter((repo): repo is RepositoryConfig => typeof repo !== 'undefined')
-    );
+    repositories.push(...config.config.repositories.map(normalizeRepository));
   }
 
   return {


### PR DESCRIPTION
Since we're using project config, we don't need to skip repositories that cannot be decrypted.

Reverts xing/canarist#58