### PR TITLE
feat: correctly resolve file package paths in root resolutions

### DIFF
--- a/src/__tests__/workspaces.test.ts
+++ b/src/__tests__/workspaces.test.ts
@@ -220,6 +220,25 @@ describe('createRootManifest', () => {
     });
   });
 
+  it('should resolve file packages in resolutions', () => {
+    const manifest = createRootManifest(
+      partialWorkspacesConfig({
+        repositories: [
+          partialWorkspacesRepositoryConfig({
+            url: 'https://github.com/xing/hops.git',
+            directory: 'hops',
+            manifest: {
+              ...hopsManifest,
+              resolutions: { stub: 'file:lib/stub' },
+            },
+          }),
+        ],
+      })
+    );
+
+    expect(manifest.resolutions?.stub).toBe('file:hops/lib/stub');
+  });
+
   it('should merge workspaces of root manifests', () => {
     const manifest = createRootManifest(
       partialWorkspacesConfig({


### PR DESCRIPTION
This covers an edge-case where I need to stub a transient dependency, which annoys me with failing creations of native bindings that aren't needed anyways. So I point that package to a local stub like this…

```json
{
  "resolutions": {
    "annoying-package": "file:some-dir/annoying-package"
  }
}
```

This works fine locally. But with Canarist it fails, because from the within the root-manifest that resolution file path is not correct.

This PR fixes this by resolving file path resolutions to its origin repo directory.